### PR TITLE
Fix tutorial tooltip background color

### DIFF
--- a/js/hack_tutorial/codemirror/addon/lint/lint.css
+++ b/js/hack_tutorial/codemirror/addon/lint/lint.css
@@ -4,10 +4,10 @@
 }
 
 .CodeMirror-lint-tooltip {
-  background-color: infobackground;
+  background-color: #ffd;
   border: 1px solid black;
   border-radius: 4px 4px 4px 4px;
-  color: infotext;
+  color: black;
   font-family: monospace;
   font-size: 10pt;
   overflow: hidden;


### PR DESCRIPTION
From upstream fix in CodeMirror https://github.com/codemirror/CodeMirror/commit/0ca8205af4a691683ce336949780e8d42e05cd52
Fixes #2