### PR TITLE
Fix example snippet on Generics section of the homepage

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -205,7 +205,7 @@ class Index extends React.Component {
                 <div className="blockImage">
                   <div>
                     <MarkdownBlock>
-                      {typeAnnotationExample}
+                      {genericsExample}
                     </MarkdownBlock>
                   </div>
                 </div>


### PR DESCRIPTION
The snippet on the Generics section on the homepage is mistakenly showing the type annotation example again. There is a genericsExample defined on the index source, so I think that is what was intended to appear there.