### PR TITLE
Link to the Hack directory within the HHVM repo

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -41,7 +41,7 @@ const siteConfig = {
       label: 'Spec',
     },
     {
-      href: 'http://github.com/facebook/hhvm',
+      href: 'https://github.com/facebook/hhvm/tree/master/hphp/hack',
       label: 'GitHub',
     },
     {


### PR DESCRIPTION
This helps users find where in the HHVM repo the Hacklang source code is. It's not immediately obvious otherwise.

This directory has also has a useful README and prevents confusion of the VM with the Hack tooling.