### PR TITLE
Use a secondary colour with sufficient contrast

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -70,7 +70,7 @@ const siteConfig = {
   /* colors for website */
   colors: {
     primaryColor: '#505050',
-    secondaryColor: '#f9f9f9',
+    secondaryColor: '#24292e',
   },
 
   /* custom fonts for website */


### PR DESCRIPTION
On small laptops and mobile devices the navigation bar wraps, which
requires the secondary colour to have sufficient contrast from the
link text colour.

Before:

![screenshot before](https://user-images.githubusercontent.com/70800/43209340-4508f370-9024-11e8-8093-cb48f7acaf26.png)

After:

![screenshot after](https://user-images.githubusercontent.com/70800/43209299-3495798c-9024-11e8-88f9-da6d557136d1.png)
