### PR TITLE
Fixing formatting for sample Hack code

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -16,48 +16,49 @@ const translate = require("../../server/translate.js").translate;
 const pre = "```";
 const asyncExample= `${pre}hack
 <<__EntryPoint>>
-  async function my_example(): Awaitable<void> {
-    $user_ids = vec[1, 2, 3];
+async function my_example(): Awaitable<void> {
+  $user_ids = vec[1, 2, 3];
 
-    // Initiate all the database requests together,
-    // so we spend less time waiting.
-    $user_names = await Vec\map_async(
-      $user_ids,
-      async ($id) ==> await fetch_user_name($id),
-    );
-    // Execution continues after requests complete.
+  // Initiate all the database requests together,
+  // so we spend less time waiting.
+  $user_names = await Vec\\map_async(
+    $user_ids,
+    async ($id) ==> await fetch_user_name($id),
+  );
+  // Execution continues after requests complete.
 
-    echo Str\join($user_names, ", ");
-  }
+  echo Str\\join($user_names, ", ");
+}
 
-  async function fetch_user_name(int $_):
-    Awaitable<string> {
-      // This could be a database request.
-      return "";
-    }
+async function fetch_user_name(
+  int $_,
+): Awaitable<string> {
+  // This could be a database request.
+  return "";
+}
 ${pre}`;
 const genericsExample = `${pre}hack
-  class Box<T> {
-    protected T $data;
+class Box<T> {
+  protected T $data;
 
-    public function __construct(T $data) {
-      $this->data = $data;
-    }
-
-    public function getData(): T {
-      return $this->data;
-    }
+  public function __construct(T $data) {
+    $this->data = $data;
   }
+
+  public function getData(): T {
+    return $this->data;
+  }
+}
 ${pre}`;
 const XHPExample = `${pre}hack
-  // Traditional: Risky and easy to misplace tags!
-  $user_name = 'Fred';
-  echo "<tt>Hello <strong>$user_name</tt></strong>";
+// Traditional: Risky and easy to misplace tags!
+$user_name = 'Fred';
+echo "<tt>Hello <strong>$user_name</tt></strong>";
 
-  // XHP: Typechecked, well-formed, and secure
-  $user_name = 'Andrew';
-  $xhp = <tt>Hello <strong>{$user_name}</strong></tt>;
-  echo await $xhp->toStringAsync();
+// XHP: Typechecked, well-formed, and secure
+$user_name = 'Andrew';
+$xhp = <tt>Hello <strong>{$user_name}</strong></tt>;
+echo await $xhp->toStringAsync();
 ${pre}`;
 class Button extends React.Component {
   render() {


### PR DESCRIPTION
On the website right now the example code blocks are formatted poorly and improperly escaped which looks bad, in my opinion. This PR tweaks the formatting of the sample code to be consistent, properly escaped, and more in-line with the standard Hack style formatting.

# Before

<img width="554" alt="Screen Shot 2021-06-30 at 13 35 13" src="https://user-images.githubusercontent.com/4632233/124028083-6f4d4480-d9a8-11eb-996b-9ea290c3c195.png">

# After

<img width="544" alt="Screen Shot 2021-06-30 at 13 39 54" src="https://user-images.githubusercontent.com/4632233/124028478-e2ef5180-d9a8-11eb-8ca7-0a20900827d1.png">

