### PR TITLE
docs: adding ELI5 video to the home page 

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -107,6 +107,30 @@ class HomeSplash extends React.Component {
   }
 }
 
+
+function VideoContainer() {
+  return (
+    <div align="center" className="container margin-bottom--xl">
+      <div className="row">
+        <div className="col">
+          <h2>Watch Introductory Video</h2>
+          <div>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/XlWUUWS2UEE"
+              title="Explain Like I'm 5: Hack"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 class Index extends React.Component {
   render() {
     let language = this.props.language || "en";
@@ -115,6 +139,7 @@ class Index extends React.Component {
       <div>
         <HomeSplash language={language} />
         <div className="mainContainer">
+          <VideoContainer />
           <Container padding={["bottom"]}>
             <GridBlock
               align="center"


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Recoil](https://recoiljs.org/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

## Test plan
![image](https://user-images.githubusercontent.com/12485205/155422463-1cf76fd8-3126-47da-af47-99ab67feb82d.png)
