### PR TITLE
Update root path for GH pages artefact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: build
+          path: build/hacklang.org
 
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
Quick fix for #38  (https://hacklang.org/hacklang.org/ -> https://hacklang.org/) 🤦‍♂️

Getting rid of the `hacklang.org/` prefix in the GH pages artefact that is used for deployment;
ex. on fork: https://github.com/tlil/hacklang.org/actions/runs/18940526635/job/54077900420